### PR TITLE
Add priority attribute to cookie

### DIFF
--- a/src/cookie/index.ts
+++ b/src/cookie/index.ts
@@ -6,6 +6,7 @@ export interface CookieAttributes {
 	httpOnly?: boolean;
 	maxAge?: number;
 	expires?: Date;
+	priority?: "low" | "medium" | "high";
 }
 
 export function serializeCookie(
@@ -41,6 +42,15 @@ export function serializeCookie(
 	}
 	if (attributes?.secure) {
 		keyValueEntries.push(["Secure"]);
+	}
+	if (attributes?.priority === "low") {
+		keyValueEntries.push(["Priority", "Low"]);
+	}
+	if (attributes?.priority === "medium") {
+		keyValueEntries.push(["Priority", "Medium"]);
+	}
+	if (attributes?.priority === "high") {
+		keyValueEntries.push(["Priority", "High"]);
 	}
 	return keyValueEntries.map((pair) => pair.join("=")).join("; ");
 }


### PR DESCRIPTION
I've added priority to `CookieAttributes` and added proper handling for it. I've spotted that you decided to use lowercase values for `sameSite` and three different branches in `serializeCookie` fn for it. Decided to do exactly the same for priority, but I'm open to adjust it if needed 😃 

Edit: afaik it's not fully standard but I think it's really useful to use and it seems like you support in in Lucia