### PR TITLE
(nit) Minor fix in request domain handling for origin verification for IDN

### DIFF
--- a/src/request/index.test.ts
+++ b/src/request/index.test.ts
@@ -27,6 +27,11 @@ describe("verifyRequestOrigin()", () => {
 				allowedSubdomains: ["foo"]
 			})
 		).toBe(true);
+		expect(
+			verifyRequestOrigin("http://xn--zckzah.xn--zckzah", "テスト", {
+				allowedSubdomains: ["テスト"]
+			})
+		).toBe(true);
 	});
 
 	test("ignores base domain by default", () => {

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -24,7 +24,7 @@ export function verifyRequestOrigin(
 		return originHost === host;
 	}
 	for (const allowedSubdomain of allowedSubdomains) {
-		if (originHost === allowedSubdomain + "." + host) {
+		if (originHost === safeURL(allowedSubdomain + "." + host)?.host) {
 			return true;
 		}
 	}


### PR DESCRIPTION
This is very nit picking and not sure if the additional computation cost makes sense, but the current implementation seems to be missing a corner case for handling IDN subdomains where user agents convert entire domain name to puny code.
