### PR TITLE
JWT typ header is optional

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -119,10 +119,10 @@ export function parseJWT(jwt: string): JWT | null {
 	if (typeof header !== "object" || header === null) {
 		return null;
 	}
-	if (!("typ" in header) || !("alg" in header)) {
+	if (!("alg" in header) || !isValidAlgorithm(header.alg)) {
 		return null;
 	}
-	if (!isValidAlgorithm(header.alg) || header.typ !== "JWT") {
+	if ("typ" in header && header.typ !== "JWT") {
 		return null;
 	}
 	const payload: unknown = JSON.parse(textDecoder.decode(rawPayload));


### PR DESCRIPTION
https://openid.net/specs/draft-jones-json-web-token-07.html#ReservedClaimName "The typ (type) claim is used to declare a type for the contents of this JWT Claims Set. The typ value is case sensitive. This claim is OPTIONAL."

Apple's identity token used for 'Sign in with Apple' was failing to be parsed and verified by oslo due to not including a typ header. It just has the alg and kid.

ex.
```json
{
  "kid": "YuyXoY",
  "alg": "RS256"
}
```
