### PR TITLE
scope: remove duplicates

### DIFF
--- a/src/oauth2/core.ts
+++ b/src/oauth2/core.ts
@@ -37,7 +37,7 @@ export class OAuth2Client {
 		codeVerifier?: string;
 		scope?: string[];
 	}): Promise<URL> {
-		const scope = options?.scope ?? [];
+		const scope = Array.from(new Set(options?.scope ?? [])); // remove duplicates
 		const authorizationUrl = new URL(this.authorizeEndpoint);
 		authorizationUrl.searchParams.set("response_type", "code");
 		authorizationUrl.searchParams.set("response_mode", this.responseMode);


### PR DESCRIPTION
We get duplicate scopes when the user adds a scope that also gets added automatically by the arctic provider.
for example:
this.scope.push("users.read");
this.scope.push("identify");
this.scope.push("openid", "profile");

PS: This is my very first Pull Request. I hope I didnt make a mistake. ;-)