### PR TITLE
Allow JWT aud to be a string

### DIFF
--- a/docs/pages/reference/jwt/JWT.md
+++ b/docs/pages/reference/jwt/JWT.md
@@ -18,7 +18,7 @@ interface JWT {
 	expiresAt: Date | null;
 	issuer: string | null;
 	subject: string | null;
-	audience: string[] | null;
+	audiences: string[] | null;
 	notBefore: Date | null;
 	issuedAt: Date | null;
 	jwtId: string | null;
@@ -35,7 +35,7 @@ interface JWT {
 - `expiresAt`: `exp` claim
 - `issuer`: `iss` claim
 - `subject`: `sub` claim
-- `audience`: `aud` claim
+- `audiences`: `aud` claims
 - `notBefore`: `nbf` claim
 - `issuedAt`: `iat` claim
 - `jwtId`: `jti` claim

--- a/docs/pages/reference/jwt/createJWT.md
+++ b/docs/pages/reference/jwt/createJWT.md
@@ -20,7 +20,7 @@ function createJWT(
 		expiresIn?: $$TimeSpan;
 		issuer?: string;
 		subject?: string;
-		audience?: string[];
+		audiences?: string[];
 		notBefore?: Date;
 		includeIssuedTimestamp?: boolean;
 		jwtId?: string;
@@ -38,7 +38,7 @@ function createJWT(
   - `expiresIn`: How long the JWT is valid for (for `exp` claim)
   - `issuer`: `iss` claim
   - `subject`: `sub` claim
-  - `audience`: `aud` claims
+  - `audiences`: `aud` claims
   - `notBefore`: `nbf` claim
   - `includeIssuedTimestamp` (default: `false`): Set to `true` to include `iat` claim
   - `jwtId`: `jti` claim

--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -159,14 +159,18 @@ export function parseJWT(jwt: string): JWT | null {
 	}
 	if ("aud" in payload) {
 		if (!Array.isArray(payload.aud)) {
-			return null;
-		}
-		for (const item of payload.aud) {
-			if (typeof item !== "string") {
+			if (typeof payload.aud !== "string") {
 				return null;
 			}
+			properties.audiences = [payload.aud];
+		} else {
+			for (const item of payload.aud) {
+				if (typeof item !== "string") {
+					return null;
+				}
+			}
+			properties.audiences = payload.aud;
 		}
-		properties.audiences = payload.aud;
 	}
 	if ("nbf" in payload) {
 		if (typeof payload.nbf !== "number") {


### PR DESCRIPTION
Per the spec:
> In the special case when the JWT has one audience, the "aud" value MAY be
> a single case-sensitive string containing a StringOrURI value.

https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3

I ran into this with my Apple ID token not being parsed. It uses a string for the aud value. Thanks!