### PR TITLE
Change JWT payload and header types to Record<string, any>

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -218,8 +218,8 @@ interface JWTProperties {
 
 export interface JWT extends JWTProperties {
 	value: string;
-	header: object;
-	payload: object;
+	header: Record<string, any>;
+	payload: Record<string, any>;
 	parts: [header: string, payload: string, signature: string];
 }
 


### PR DESCRIPTION
Currently the `header` and `payload` fields of `JWT` are of type `object`.

A `Record<string, any>` would be more appropriate for this as an `object` type is equivalent to an empty object, of which you can't index.