### PR TITLE
Add scope option to oauth2 refresh function

### DIFF
--- a/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
+++ b/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
@@ -31,7 +31,7 @@ function refreshAccessToken<_TokenResponseBody extends TokenResponseBody>(
 - `options`
   - `credentials`: Client password or secret for authenticated requests
   - `authenticateWith` (default: `"http_basic_auth"`): How the credentials should be sent
-  - `scopes`: Optional scopes to pass to the token endpoint when refreshing. Certain providers require this.
+  - `scopes`
 
 ### Type parameters
 

--- a/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
+++ b/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
@@ -52,7 +52,7 @@ interface ResponseBody extends TokenResponseBody {
 try {
 	const tokens = await $$oauth2Client.refreshAccessToken<ResponseBody>(code, {
 		credentials: clientSecret,
-		authenticateWith: "request_body", // send client secret inside body
+		authenticateWith: "request_body" // send client secret inside body
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
+++ b/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
@@ -53,7 +53,6 @@ try {
 	const tokens = await $$oauth2Client.refreshAccessToken<ResponseBody>(code, {
 		credentials: clientSecret,
 		authenticateWith: "request_body", // send client secret inside body
-		scopes: []
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
+++ b/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
@@ -20,6 +20,7 @@ function refreshAccessToken<_TokenResponseBody extends TokenResponseBody>(
 	options?: {
 		credentials?: string;
 		authenticateWith?: "http_basic_auth" | "request_body";
+		scopes?: string[];
 	}
 ): Promise<_TokenResponseBody>;
 ```
@@ -30,6 +31,7 @@ function refreshAccessToken<_TokenResponseBody extends TokenResponseBody>(
 - `options`
   - `credentials`: Client password or secret for authenticated requests
   - `authenticateWith` (default: `"http_basic_auth"`): How the credentials should be sent
+  - `scopes`: Optional scopes to pass to the token endpoint when refreshing. Certain providers require this.
 
 ### Type parameters
 
@@ -50,7 +52,8 @@ interface ResponseBody extends TokenResponseBody {
 try {
 	const tokens = await $$oauth2Client.refreshAccessToken<ResponseBody>(code, {
 		credentials: clientSecret,
-		authenticateWith: "request_body" // send client secret inside body
+		authenticateWith: "request_body", // send client secret inside body
+		scopes: [] // optional scopes, required by some providers
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
+++ b/docs/pages/reference/oauth2/OAuth2Client/refreshAccessToken.md
@@ -53,7 +53,7 @@ try {
 	const tokens = await $$oauth2Client.refreshAccessToken<ResponseBody>(code, {
 		credentials: clientSecret,
 		authenticateWith: "request_body", // send client secret inside body
-		scopes: [] // optional scopes, required by some providers
+		scopes: []
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/index.md
+++ b/docs/pages/reference/oauth2/index.md
@@ -115,7 +115,7 @@ try {
 		refreshToken: string;
 	}>(code, {
 		credentials: clientSecret,
-		authenticateWith: "request_body",
+		authenticateWith: "request_body"
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/index.md
+++ b/docs/pages/reference/oauth2/index.md
@@ -115,7 +115,8 @@ try {
 		refreshToken: string;
 	}>(code, {
 		credentials: clientSecret,
-		authenticateWith: "request_body"
+		authenticateWith: "request_body",
+		scopes: []
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/docs/pages/reference/oauth2/index.md
+++ b/docs/pages/reference/oauth2/index.md
@@ -116,7 +116,6 @@ try {
 	}>(code, {
 		credentials: clientSecret,
 		authenticateWith: "request_body",
-		scopes: []
 	});
 } catch (e) {
 	if (e instanceof OAuth2RequestError) {

--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -72,12 +72,18 @@ export class OAuth2Client {
 		options?: {
 			credentials?: string;
 			authenticateWith?: "http_basic_auth" | "request_body";
+			scopes?: string[];
 		}
 	): Promise<_TokenResponseBody> {
 		const body = new URLSearchParams();
 		body.set("refresh_token", refreshToken);
 		body.set("client_id", this.clientId);
 		body.set("grant_type", "refresh_token");
+		
+		const scopes = Array.from(new Set(options?.scopes ?? [])); // remove duplicates
+		if (scopes.length > 0) {
+			body.set("scope", scopes.join(" "));
+		}
 
 		return await this.sendTokenRequest<_TokenResponseBody>(body, options);
 	}

--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -79,7 +79,7 @@ export class OAuth2Client {
 		body.set("refresh_token", refreshToken);
 		body.set("client_id", this.clientId);
 		body.set("grant_type", "refresh_token");
-		
+
 		const scopes = Array.from(new Set(options?.scopes ?? [])); // remove duplicates
 		if (scopes.length > 0) {
 			body.set("scope", scopes.join(" "));
@@ -119,7 +119,7 @@ export class OAuth2Client {
 		});
 		const response = await fetch(request);
 		const result: _TokenResponseBody | TokenErrorResponseBody = await response.json();
-        
+
 		// providers are allowed to return non-400 status code for errors
 		if (!("access_token" in result) && "error" in result) {
 			throw new OAuth2RequestError(request, result);


### PR DESCRIPTION
This adds the option to send scopes in the `refreshAccessToken` function of the OAuth2 client.

Fixes #18 