### PR TITLE
Auri: Release request (v1.1.0)

### DIFF
--- a/.changesets/47hsl.minor.md
+++ b/.changesets/47hsl.minor.md
@@ -1,1 +1,0 @@
-Deprecate `encodeBase32()`, `decodeBase32()`, `encodeBase64`, `decodeBase64()`, `encodeBase64url()`, `decodeBase64url()`.

--- a/.changesets/9cskw.minor.md
+++ b/.changesets/9cskw.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `Base64Encoding`, `Base32Encoding`, `base16`, `base32`, `base32hex`, `base64`, `base64url`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # oslo
 
+## 1.1.0
+
+### Minor changes
+
+- Deprecate `encodeBase32()`, `decodeBase32()`, `encodeBase64`, `decodeBase64()`, `encodeBase64url()`, `decodeBase64url()`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
+- Feat: Add `Base64Encoding`, `Base32Encoding`, `base16`, `base32`, `base32hex`, `base64`, `base64url`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
+
 ## 1.0.4
 
 ### Patch changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "oslo",
 	"type": "module",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "A collection of auth-related utilities",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Minor changes
- Deprecate `encodeBase32()`, `decodeBase32()`, `encodeBase64`, `decodeBase64()`, `encodeBase64url()`, `decodeBase64url()`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
- Feat: Add `Base64Encoding`, `Base32Encoding`, `base16`, `base32`, `base32hex`, `base64`, `base64url`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
