### PR TITLE
fix encoding tests: avoid using node:test

### DIFF
--- a/src/encoding/base32.test.ts
+++ b/src/encoding/base32.test.ts
@@ -1,8 +1,6 @@
-import { expect } from "vitest";
-import { test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { base32 as base32Reference } from "@scure/base";
 import { base32 } from "./base32.js";
-import { describe } from "node:test";
 
 describe("Base32.encode()", () => {
 	test("Generates valid string", () => {

--- a/src/encoding/base64.test.ts
+++ b/src/encoding/base64.test.ts
@@ -1,7 +1,5 @@
-import { expect } from "vitest";
-import { test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { base64 } from "./base64.js";
-import { describe } from "node:test";
 
 describe("Base64.encode()", () => {
 	test("Generates valid string", () => {

--- a/src/encoding/hex.test.ts
+++ b/src/encoding/hex.test.ts
@@ -1,7 +1,5 @@
-import { expect } from "vitest";
-import { test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { encodeHex, decodeHex } from "./hex.js";
-import { describe } from "node:test";
 
 describe("encodeHex()", () => {
 	test("Generates valid hex string", () => {


### PR DESCRIPTION
A small regression from #35, nothing major but inconsistent with broader codebase and avoids it working out-of-the-box with `bun` etc...