### PR TITLE
perf: simpler & faster base32 encode

### DIFF
--- a/.changesets/r9sme.patch.md
+++ b/.changesets/r9sme.patch.md
@@ -1,0 +1,1 @@
+Improve `base32.encode()` performance.

--- a/src/encoding/base32.ts
+++ b/src/encoding/base32.ts
@@ -46,7 +46,8 @@ export class Base32Encoding implements Encoding {
 		if (shift > 0) {
 			result += this.alphabet[(block << (5 - shift)) & 0x1f];
 		}
-		if (options?.includePadding ?? true) {
+		const includePadding = options?.includePadding ?? true;
+		if (includePadding) {
 			const padCount = (8 - (result.length % 8)) % 8;
 			for (let i = 0; i < padCount; i++) {
 				result += "=";

--- a/src/encoding/base32.ts
+++ b/src/encoding/base32.ts
@@ -33,29 +33,21 @@ export class Base32Encoding implements Encoding {
 		}
 	): string {
 		let result = "";
-		const chunkCount = Math.ceil(data.length / 5);
-		for (let i = 0; i < chunkCount; i++) {
-			let buffer1 = data[i * 5]! << 24;
-			buffer1 += (data[i * 5 + 1] ?? 0) << 16;
-			buffer1 += (data[i * 5 + 2] ?? 0) << 8;
-			buffer1 += data[i * 5 + 3] ?? 0;
-			for (let j = 0; j < 6; j++) {
-				const key = (buffer1 >> (27 - 5 * j)) & 0x1f;
-				result += this.alphabet[key];
+		let block = 0;
+		let shift = 0;
+		for (let i = 0; i < data.length; i++) {
+			block = (block << 8) | data[i]!;
+			shift += 8;
+			while (shift >= 5) {
+				shift -= 5;
+				result += this.alphabet[(block >> shift) & 0x1f];
 			}
-			const buffer2 = data[i * 5 + 4] ?? 0;
-			let key = ((buffer1 & 0x03) << 3) + (buffer2 >> 5);
-			result += this.alphabet[key];
-			key = buffer2 & 0x1f;
-			result += this.alphabet[key];
 		}
-		let padCount = 0;
-		if (data.length % 5 !== 0) {
-			padCount = 8 - Math.ceil(((data.length % 5) * 8) / 5);
+		if (shift > 0) {
+			result += this.alphabet[(block << (5 - shift)) & 0x1f];
 		}
-		result = result.slice(0, result.length - padCount);
-		const includePadding = options?.includePadding ?? true;
-		if (includePadding) {
+		if (options?.includePadding ?? true) {
+			const padCount = (8 - (result.length % 8)) % 8;
 			for (let i = 0; i < padCount; i++) {
 				result += "=";
 			}


### PR DESCRIPTION
This is mainly a PoC, similar room for optimization in other encodings.
TLDR: >3x faster on `jsc/bun`, 1.4x faster on `v8/deno`

## Before

```bash
❯ deno run ./src/encoding/base32.bench.ts
Starting base32 encoding benchmark...
1 000 000 iterations of base32 encoding took 574.00ms
Average cost per iteration: 574.00ns

❯ bun run ./src/encoding/base32.bench.ts
Starting base32 encoding benchmark...
1,000,000 iterations of base32 encoding took 870.48ms
Average cost per iteration: 870.48ns
```

## After

```sh
❯ deno run ./src/encoding/base32.bench.ts
Starting base32 encoding benchmark...
1 000 000 iterations of base32 encoding took 410.00ms
Average cost per iteration: 410.00ns

❯ bun run ./src/encoding/base32.bench.ts
Starting base32 encoding benchmark...
1,000,000 iterations of base32 encoding took 263.55ms
Average cost per iteration: 263.55ns
```

## Bench code

```ts
import { base32 } from "./base32.ts";

const data = crypto.getRandomValues(new Uint8Array(32)); // 32 bytes of random data

console.log("Starting base32 encoding benchmark...");

const start = performance.now();
const N = 1e6;

for (let i = 0; i < N; i++) {
	base32.encode(data);
}

const end = performance.now();
const dt = end - start;
const dtAvg = dt / N;

// Convert duration and cost per iteration to appropriate units
function tUnit(value: number): string {
	if (value < 0.001) {
		return `${(value * 1000000).toFixed(2)}ns`;
	} else if (value < 1) {
		return `${(value * 1000).toFixed(2)}µs`;
	} else {
		return `${value.toFixed(2)}ms`;
	}
}

console.log(`${N.toLocaleString()} iterations of base32 encoding took ${tUnit(dt)}`);
console.log(`Average cost per iteration: ${tUnit(dtAvg)}`);
```