### PR TITLE
Export OAuth2 token response interfaces

### DIFF
--- a/.changesets/hrcfb.patch.md
+++ b/.changesets/hrcfb.patch.md
@@ -1,0 +1,1 @@
+Export OAuth2 token response interfaces

--- a/.changesets/hrcfb.patch.md
+++ b/.changesets/hrcfb.patch.md
@@ -1,1 +1,1 @@
-Export OAuth2 token response interfaces
+Export OAuth2 token response interface

--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -162,12 +162,12 @@ export class OAuth2RequestError extends Error {
 	}
 }
 
-interface TokenErrorResponseBody {
+export interface TokenErrorResponseBody {
 	error: string;
 	error_description?: string;
 }
 
-interface TokenResponseBody {
+export interface TokenResponseBody {
 	access_token: string;
 	token_type?: string;
 	expires_in?: number;

--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -162,7 +162,7 @@ export class OAuth2RequestError extends Error {
 	}
 }
 
-export interface TokenErrorResponseBody {
+interface TokenErrorResponseBody {
 	error: string;
 	error_description?: string;
 }


### PR DESCRIPTION
The examples in the [documentation](https://oslo.js.org/reference/oauth2/OAuth2Client/validateAuthorizationCode) show that one can extend the `TokenResponseBody` interface, e.g. to add an id_token for OpenId Connect. However, that interface is not exported from the library. This PR is a tiny fix to export both interfaces which cover the token response types.