### PR TITLE
fix bun validateAuthorizationCode not working 

### DIFF
--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -123,7 +123,10 @@ export class OAuth2Client {
 			headers,
 			body
 		});
-		const response = await fetch(request);
+		const response = await fetch(request, {
+			// workaround for a bun bug
+			method: "POST"
+		});
 		const result: _TokenResponseBody | TokenErrorResponseBody = await response.json();
 
 		// providers are allowed to return non-400 status code for errors


### PR DESCRIPTION
sveltekit
bun v1.0.29

```js
await discord.validateAuthorizationCode(code);
``` 
will fail with a 405 response from discord (even though it works in node with 0 code changes), this PR just adds a simple workaround that I believe is harmless and solves this issue