### PR TITLE
Auri: Release request (v2.0.0-next.0)

### DIFF
--- a/.changesets/32ofn.minor.md
+++ b/.changesets/32ofn.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `SigningAlgorithm` interface

--- a/.changesets/450g.major.md
+++ b/.changesets/450g.major.md
@@ -1,1 +1,0 @@
-Breaking: Update `OAuth2RequestError`

--- a/.changesets/a1o5w.minor.md
+++ b/.changesets/a1o5w.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `createJWTHeader()` and `createJWTPayload()`

--- a/.changesets/a8v49.minor.md
+++ b/.changesets/a8v49.minor.md
@@ -1,1 +1,0 @@
-Feat: `sha1()`, `sha256()`, `sha384()`, and `sha512()` is synchronous

--- a/.changesets/a9v5m.major.md
+++ b/.changesets/a9v5m.major.md
@@ -1,1 +1,0 @@
-Breaking: Update `OAuth2Client`

--- a/.changesets/anacy.minor.md
+++ b/.changesets/anacy.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `TokenRevocationClient`, `TokenRevocationRetryError`, and `TokenRevocationRequestContext`

--- a/.changesets/byh56.major.md
+++ b/.changesets/byh56.major.md
@@ -1,1 +1,0 @@
-Breaking: Remove `oslo/password`

--- a/.changesets/eyjwv.major.md
+++ b/.changesets/eyjwv.major.md
@@ -1,1 +1,0 @@
-Breaking: Remove `oslo/request`

--- a/.changesets/hitcz.major.md
+++ b/.changesets/hitcz.major.md
@@ -1,1 +1,0 @@
-Breaking: Update `createJWT()` and `validateJWT()` parameters

--- a/.changesets/jvllp.major.md
+++ b/.changesets/jvllp.major.md
@@ -1,1 +1,0 @@
-Breaking: Replace `oslo/webauthn` with `oslo/passkey`

--- a/.changesets/k0utl.major.md
+++ b/.changesets/k0utl.major.md
@@ -1,1 +1,0 @@
-Breaking: Rename `createDate()` to `addToDate()`

--- a/.changesets/mjf9y.minor.md
+++ b/.changesets/mjf9y.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `oslo/binary`

--- a/.changesets/p2blk.major.md
+++ b/.changesets/p2blk.major.md
@@ -1,1 +1,0 @@
-Breaking: Remove `encodeBase32()`, `decodeBase32()`, `encodeBase64()`, `decodeBase64()`, `encodeBase64url()`, and `decodeBase64url()`,

--- a/.changesets/t5acy.minor.md
+++ b/.changesets/t5acy.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `OAuth2RequestError`

--- a/.changesets/u280g.major.md
+++ b/.changesets/u280g.major.md
@@ -1,1 +1,0 @@
-Breaking: Functions only accept `Uint8Array` instead of `TypedArray | ArrayBuffer`

--- a/.changesets/vjh9f.minor.md
+++ b/.changesets/vjh9f.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `OAuth2RequestContext`, `AccessTokenRequestContext`, `RefreshTokenRequestContext`, and `OAuth2Request`

--- a/.changesets/xiah5.minor.md
+++ b/.changesets/xiah5.minor.md
@@ -1,1 +1,0 @@
-Feat: Add `generateRandomBoolean()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,26 @@
 # oslo
 
-## 1.2.0
+## 2.0.0-next.0
 
-### Minor changes
+## Major changes
 
-- Feat: Add `codeChallengeMethod` option to `OAuth2Client.createAuthorizationURL()` ([#29](https://github.com/pilcrowOnPaper/oslo/pull/29))
+- Breaking: Update `OAuth2RequestError`
+- Breaking: Update `OAuth2Client`
+- Breaking: Remove `oslo/password`
+- Breaking: Remove `oslo/request`
+- Breaking: Update `createJWT()` and `validateJWT()` parameters
+- Breaking: Replace `oslo/webauthn` with `oslo/passkey`
+- Breaking: Rename `createDate()` to `addToDate()`
+- Breaking: Remove `encodeBase32()`, `decodeBase32()`, `encodeBase64()`, `decodeBase64()`, `encodeBase64url()`, and `decodeBase64url()`,
+- Breaking: Functions only accept `Uint8Array` instead of `TypedArray | ArrayBuffer`
 
-## 1.1.3
+## Minor changes
 
-### Patch changes
-
-- Update dependencies. ([#51](https://github.com/pilcrowOnPaper/oslo/pull/51))
-
-## 1.1.2
-
-### Patch changes
-
-- Export OAuth2 token response interface ([#45](https://github.com/pilcrowOnPaper/oslo/pull/45))
-- Fix client data JSON validation
-
-## 1.1.1
-
-### Patch changes
-
-- Improve `base64.encode()` performance
-- Improve `base32.encode()` performance. ([#40](https://github.com/pilcrowOnPaper/oslo/pull/40))
-
-## 1.1.0
-
-### Minor changes
-
-- Deprecate `encodeBase32()`, `decodeBase32()`, `encodeBase64`, `decodeBase64()`, `encodeBase64url()`, `decodeBase64url()`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
-- Feat: Add `Base64Encoding`, `Base32Encoding`, `base16`, `base32`, `base32hex`, `base64`, `base64url`. ([#35](https://github.com/pilcrowOnPaper/oslo/pull/35))
-
-## 1.0.4
-
-### Patch changes
-
-- Fix: Export `TimeSpanUnit` ([#30](https://github.com/pilcrowOnPaper/oslo/pull/30))
-
-## 1.0.3
-
-- Pin `@node-rs/argon2` and `@node-rs/bcrypt` versions [#26](https://github.com/pilcrowOnPaper/oslo/pull/26)
+- Feat: Add `SigningAlgorithm` interface
+- Feat: Add `createJWTHeader()` and `createJWTPayload()`
+- Feat: `sha1()`, `sha256()`, `sha384()`, and `sha512()` is synchronous
+- Feat: Add `TokenRevocationClient`, `TokenRevocationRetryError`, and `TokenRevocationRequestContext`
+- Feat: Add `oslo/binary`
+- Feat: Add `OAuth2RequestError`
+- Feat: Add `OAuth2RequestContext`, `AccessTokenRequestContext`, `RefreshTokenRequestContext`, and `OAuth2Request`
+- Feat: Add `generateRandomBoolean()`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "oslo",
 	"type": "module",
-	"version": "1.2.0",
+	"version": "2.0.0-next.0",
 	"description": "A collection of auth-related utilities",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Major changes
- Breaking: Update `OAuth2RequestError`
- Breaking: Update `OAuth2Client`
- Breaking: Remove `oslo/password`
- Breaking: Remove `oslo/request`
- Breaking: Update `createJWT()` and `validateJWT()` parameters
- Breaking: Replace `oslo/webauthn` with `oslo/passkey`
- Breaking: Rename `createDate()` to `addToDate()`
- Breaking: Remove `encodeBase32()`, `decodeBase32()`, `encodeBase64()`, `decodeBase64()`, `encodeBase64url()`, and `decodeBase64url()`,
- Breaking: Functions only accept `Uint8Array` instead of `TypedArray | ArrayBuffer`
## Minor changes
- Feat: Add `SigningAlgorithm` interface
- Feat: Add `createJWTHeader()` and `createJWTPayload()`
- Feat: `sha1()`, `sha256()`, `sha384()`, and `sha512()` is synchronous
- Feat: Add `TokenRevocationClient`, `TokenRevocationRetryError`, and `TokenRevocationRequestContext`
- Feat: Add `oslo/binary`
- Feat: Add `OAuth2RequestError`
- Feat: Add `OAuth2RequestContext`, `AccessTokenRequestContext`, `RefreshTokenRequestContext`, and `OAuth2Request`
- Feat: Add `generateRandomBoolean()`
