### PR TITLE
Auri: Release request (v1.2.1)

### DIFF
--- a/.changesets/1719416300-a6fzo.patch.md
+++ b/.changesets/1719416300-a6fzo.patch.md
@@ -1,1 +1,0 @@
-Fix `issuer` parameter getting encoded twice in key URI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # oslo
 
+## 1.2.1
+
+### Patch changes
+
+- Fix `issuer` parameter getting encoded twice in key URI ([#79](https://github.com/pilcrowOnPaper/oslo/pull/79))
+
 ## 1.2.0
 
 ### Minor changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "oslo",
 	"type": "module",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A collection of auth-related utilities",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Patch changes
- Fix `issuer` parameter getting encoded twice in key URI ([#79](https://github.com/pilcrowOnPaper/oslo/pull/79))
