### PR TITLE
feat: Add "audience" as option of "OAuth2Client"

### DIFF
--- a/src/oauth2/index.ts
+++ b/src/oauth2/index.ts
@@ -7,7 +7,7 @@ export class OAuth2Client {
 	private authorizeEndpoint: string;
 	private tokenEndpoint: string;
 	private redirectURI: string | null;
-	private audience: string | null;
+	private resource: string | null;
 
 	constructor(
 		clientId: string,
@@ -15,14 +15,14 @@ export class OAuth2Client {
 		tokenEndpoint: string,
 		options?: {
 			redirectURI?: string;
-			audience?: string,
+			resource?: string,
 		}
 	) {
 		this.clientId = clientId;
 		this.authorizeEndpoint = authorizeEndpoint;
 		this.tokenEndpoint = tokenEndpoint;
 		this.redirectURI = options?.redirectURI ?? null;
-		this.audience = options?.audience ?? null;
+		this.resource = options?.resource ?? null;
 	}
 
 	public async createAuthorizationURL(options?: {
@@ -30,7 +30,7 @@ export class OAuth2Client {
 		codeVerifier?: string;
 		codeChallengeMethod?: "S256" | "plain";
 		scopes?: string[];
-		audience?: string;
+		resource?: string;
 	}): Promise<URL> {
 		const scopes = Array.from(new Set(options?.scopes ?? [])); // remove duplicates
 		const authorizationUrl = new URL(this.authorizeEndpoint);
@@ -45,8 +45,8 @@ export class OAuth2Client {
 		if (this.redirectURI !== null) {
 			authorizationUrl.searchParams.set("redirect_uri", this.redirectURI);
 		}
-		if (this.audience != null || options?.audience !== undefined){
-			authorizationUrl.searchParams.set("audience", options?.audience ?? this.audience!);
+		if (this.resource != null || options?.resource !== undefined){
+			authorizationUrl.searchParams.set("resource", options?.resource ?? this.resource!);
 		}
 		if (options?.codeVerifier !== undefined) {
 			const codeChallengeMethod = options?.codeChallengeMethod ?? "S256";
@@ -73,7 +73,7 @@ export class OAuth2Client {
 			codeVerifier?: string;
 			credentials?: string;
 			authenticateWith?: "http_basic_auth" | "request_body";
-			audience?: string;
+			resource?: string;
 		}
 	): Promise<_TokenResponseBody> {
 		const body = new URLSearchParams();
@@ -87,8 +87,8 @@ export class OAuth2Client {
 		if (options?.codeVerifier !== undefined) {
 			body.set("code_verifier", options.codeVerifier);
 		}
-		if (this.audience != null || options?.audience !== undefined){
-			body.set("audience", options?.audience ?? this.audience!);
+		if (this.resource != null || options?.resource !== undefined){
+			body.set("resource", options?.resource ?? this.resource!);
 		}
 		return await this.sendTokenRequest<_TokenResponseBody>(body, options);
 	}
@@ -99,7 +99,7 @@ export class OAuth2Client {
 			credentials?: string;
 			authenticateWith?: "http_basic_auth" | "request_body";
 			scopes?: string[];
-			audience?: string;
+			resource?: string;
 		}
 	): Promise<_TokenResponseBody> {
 		const body = new URLSearchParams();
@@ -107,8 +107,8 @@ export class OAuth2Client {
 		body.set("client_id", this.clientId);
 		body.set("grant_type", "refresh_token");
 
-		if (this.audience !== null || options?.audience !== undefined) {
-			body.set("audience", options?.audience ?? this.audience!);
+		if (this.resource !== null || options?.resource !== undefined) {
+			body.set("resource", options?.resource ?? this.resource!);
 		}	
 
 		const scopes = Array.from(new Set(options?.scopes ?? [])); // remove duplicates


### PR DESCRIPTION
### Resume
Add the audience parameter as optional at OAuth2Client constructor and methods.

### Evidence
> Not required

### Reference
https://github.com/pilcrowOnPaper/oslo/issues/84
[rfc8707](https://www.rfc-editor.org/rfc/rfc8707.html)